### PR TITLE
Improve notifications

### DIFF
--- a/__resource.lua
+++ b/__resource.lua
@@ -3,9 +3,17 @@ resource_manifest_version '44febabe-d386-4d18-afbe-5e627f4af937'
 description 'ESX Rob NPC'
 
 server_scripts {
-	'server/main.lua'
+     'config.lua',
+     'server/main.lua'
 }
 
 client_scripts {
-	'client/main.lua'
+    '@es_extended/locale.lua',
+    'locales/en.lua',
+    'config.lua',
+    'client/main.lua'
+}
+
+dependencies {
+    'es_extended'
 }

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,62 +1,69 @@
-ESX              = nil
-local PlayerData = {}
+ESX = nil
 
-local robbed = false
-local timeToWait = math.random(60000,1800000)
+local robbedRecently = false
 
 Citizen.CreateThread(function()
-	while ESX == nil do
-		TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
-		Citizen.Wait(0)
-	end
+    while ESX == nil do
+        TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
+        Citizen.Wait(0)
+    end
 end)
-
-RegisterNetEvent('esx:playerLoaded')
-AddEventHandler('esx:playerLoaded', function(xPlayer)
-  PlayerData = xPlayer   
-end)
-
-RegisterNetEvent('esx:setJob')
-AddEventHandler('esx:setJob', function(job)
-  PlayerData.job = job
-end)
-
 
 Citizen.CreateThread(function()
-	while true do
-		Citizen.Wait(1)
-		if IsControlJustPressed(0, 38) then
-			local aiming, targetPed = GetEntityPlayerIsFreeAimingAt(PlayerId(-1))
-			if aiming then
-			
-			local pP = GetPlayerPed(-1)
-			local pCoords = GetEntityCoords(pP, true)
-			local tCoords = GetEntityCoords(targetPed, true)
-			
-			local dict = "random@mugging3"
-			RequestAnimDict(dict)
-			while not HasAnimDictLoaded(dict) do
-			Citizen.Wait(100)
-			end
-			
-				if DoesEntityExist(targetPed) and IsEntityAPed(targetPed) then
-				-- LoadAnimationDictionary("random@mugging3")
-					if IsPedDeadOrDying(targetPed, true) then
-						ESX.ShowNotification("The guy you're robbing is dead")
-						else if GetDistanceBetweenCoords(pCoords.x, pCoords.y, pCoords.z, tCoords.x, tCoords.y, tCoords.z, true) < 3 then
-						TaskPlayAnim(targetPed, "random@mugging3", "handsup_standing_base", 8.0, -8, .01, 49, 0, 0, 0, 0)
-						FreezeEntityPosition(targetPed, true)
-						robbed = true
-						ESX.ShowNotification("You've been given money.")
-						Citizen.Wait(10000)
-						TriggerServerEvent('esx_robnpc:giveMoney')
-						FreezeEntityPosition(targetPed, false)
-						Citizen.Wait(timeToWait)
-						robbed = false
-						end
-					end
-				end
-			end
-		end
-	end
+    while true do
+        Citizen.Wait(1)
+
+        if IsControlJustPressed(0, 38) then
+            local aiming, targetPed = GetEntityPlayerIsFreeAimingAt(PlayerId(-1))
+
+            if aiming then
+                local playerPed = GetPlayerPed(-1)
+                local pCoords = GetEntityCoords(playerPed, true)
+                local tCoords = GetEntityCoords(targetPed, true)
+
+                if DoesEntityExist(targetPed) and IsEntityAPed(targetPed) then
+                    if robbedRecently then
+                        ESX.ShowNotification(_U('robbed_too_recently'))
+                    elseif IsPedDeadOrDying(targetPed, true) then
+                        ESX.ShowNotification(_U('target_dead'))
+                    elseif GetDistanceBetweenCoords(pCoords.x, pCoords.y, pCoords.z, tCoords.x, tCoords.y, tCoords.z, true) >= Config.RobDistance then
+                        ESX.ShowNotification(_U('target_too_far'))
+                    else
+                        robNpc(targetPed)
+                    end
+                end
+            end
+        end
+    end
 end)
+
+function robNpc(targetPed)
+    robbedRecently = true
+
+    Citizen.CreateThread(function()
+        local dict = 'random@mugging3'
+        RequestAnimDict(dict)
+        while not HasAnimDictLoaded(dict) do
+            Citizen.Wait(10)
+        end
+
+        TaskStandStill(targetPed, Config.RobAnimationSeconds * 1000)
+        FreezeEntityPosition(targetPed, true)
+        TaskPlayAnim(targetPed, dict, 'handsup_standing_base', 8.0, -8, .01, 49, 0, 0, 0, 0)
+        ESX.ShowNotification(_U('robbery_started'))
+
+        Citizen.Wait(Config.RobAnimationSeconds * 1000)
+
+        ESX.TriggerServerCallback('esx_robnpc:giveMoney', function(amount)
+            FreezeEntityPosition(targetPed, false)
+            ESX.ShowNotification(_U('robbery_completed', amount))
+        end)
+
+        if Config.ShouldWaitBetweenRobbing then
+            Citizen.Wait(math.random(Config.MinWaitSeconds, Config.MaxWaitSeconds) * 1000)
+            ESX.ShowNotification(_U('can_rob_again'))
+        end
+
+        robbedRecently = false
+    end)
+end

--- a/config.lua
+++ b/config.lua
@@ -1,0 +1,12 @@
+Config = {}
+Config.Locale = 'en'
+
+Config.ShouldWaitBetweenRobbing = true
+Config.MinWaitSeconds = 60
+Config.MaxWaitSeconds = 180 
+
+Config.RobDistance = 3
+Config.RobAnimationSeconds = 10
+
+Config.MinMoney = 100
+Config.MaxMoney = 500

--- a/locales/en.lua
+++ b/locales/en.lua
@@ -1,0 +1,8 @@
+Locales['en'] = {
+    ['robbed_too_recently'] = "You've robbed too recently.",
+    ['target_dead']         = "The guy you're robbing is dead.",
+    ['target_too_far']      = "Target is too far away.",
+    ['robbery_started']     = "Robbery in progress!",
+    ['robbery_completed']   = "You got ~g~$%s~s~!",
+    ['can_rob_again']       = "You can rob again!",
+}

--- a/server/main.lua
+++ b/server/main.lua
@@ -2,9 +2,9 @@ ESX = nil
 
 TriggerEvent('esx:getSharedObject', function(obj) ESX = obj end)
 
-RegisterServerEvent('esx_robnpc:giveMoney')
-AddEventHandler('esx_robnpc:giveMoney', function()
+ESX.RegisterServerCallback('esx_robnpc:giveMoney', function(source, callback)
     local xPlayer = ESX.GetPlayerFromId(source)
-	local money = math.random(100,500)
+    local money = math.random(Config.MinMoney, Config.MaxMoney)
     xPlayer.addMoney(money)
+    callback(money)
 end)


### PR DESCRIPTION
- Pull variables into config
- Add flag to skip the cooldown period after a robbery
- Pull robbery animation/wait into separate thread so notification can be displayed when you can't rob again yet
- Add notification for target too far away
- Add notification when you are able to rob again
- Add amount of money to robbery completed notification
- Attempt to make ped not run